### PR TITLE
Fix uninitialized norm bug and bump version to 0.10.1

### DIFF
--- a/CPP_Source_Code/ModifiedPolicyIteration.cpp
+++ b/CPP_Source_Code/ModifiedPolicyIteration.cpp
@@ -52,6 +52,7 @@ ModifiedPolicyIteration::ModifiedPolicyIteration(double epsilon, string algorith
 	PIparIterLim((int)1e6), //iteration limit for policy evaluation in PI
 	initPol(false),
 	initVal(false),
+	norm(numeric_limits<double>::infinity()),
 	parallel(parallel),
 	genMDP(genMDP),
 	printStuff(verbose), //set "true" to print algorithm progress at runtime

--- a/CPP_Source_Code/ModuleInterface.cpp
+++ b/CPP_Source_Code/ModuleInterface.cpp
@@ -467,16 +467,6 @@ void ModuleInterface::loadTranMatElementwise(py::list tranMatElementwise){
     for (int sidx=0; sidx<numberOfStates; sidx++){
         nCol[sidx].resize((nAct[sidx]+1),0);
     }
-    // nCol must be the *count* of transitions for each (state,action), not
-    // the largest to-state index seen. Transition targets are not
-    // guaranteed contiguous (e.g. a state may jump to states 2 and 7 but
-    // not 0,1,3,4,5,6), so sizing columns off the max index left trailing
-    // slots that never got assigned a real value - still holding
-    // TransitionMatrix::setNumberOfColumns()'s -1 "unassigned" fill value.
-    // getNumberOfJumps() (which returns this size) was then used as a loop
-    // bound in ModifiedPolicyIteration, reading vpOld[-1] - 8 bytes before
-    // the value vector's allocation - once the loop ran past the real
-    // entries into those leftover slots.
     for (int i=0; i<tranMatElementwise.size(); i++){
         innerRew = tranMatElementwise[i].cast<py::list>();
         k0 = innerRew[0].cast<int>(); k1 = innerRew[1].cast<int>();
@@ -569,16 +559,6 @@ void ModuleInterface::loadTranMatFromFile(string tranMatFromFile, char sep, bool
     file.clear();
     file.seekg(0,ios::beg);
 
-    // nCol must be the *count* of transitions for each (state,action), not
-    // the largest to-state index seen. Transition targets are not
-    // guaranteed contiguous (e.g. a state may jump to states 2 and 7 but
-    // not 0,1,3,4,5,6), so sizing columns off the max index left trailing
-    // slots that never got assigned a real value - still holding
-    // TransitionMatrix::setNumberOfColumns()'s -1 "unassigned" fill value.
-    // getNumberOfJumps() (which returns this size) was then used as a loop
-    // bound in ModifiedPolicyIteration, reading vpOld[-1] - 8 bytes before
-    // the value vector's allocation - once the loop ran past the real
-    // entries into those leftover slots.
     i=0;
     while (getline(file,line)){
         if (!header||i>0){

--- a/Python/pyproject.toml
+++ b/Python/pyproject.toml
@@ -15,7 +15,7 @@ CMAKE_BUILD_TYPE = "Release"
 
 [project]
 name = "mdpsolver"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   { name="Anders Reenberg Andersen", email="andersra@live.dk" },
   { name="Jesper Fink Andersen", email="jesperfinkandersen@gmail.com" },

--- a/Python/tests/test1.py
+++ b/Python/tests/test1.py
@@ -120,7 +120,7 @@ if not np.array_equal(np.array(mdl1a.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 1a failed!")
 if not np.array_equal(
     np.round(np.array(mdl1a.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 1a failed!")
 
@@ -138,7 +138,7 @@ if not np.array_equal(np.array(mdl2a.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 2a failed!")
 if not np.array_equal(
     np.round(np.array(mdl2a.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 2a failed!")
 
@@ -168,7 +168,7 @@ if not np.array_equal(np.array(mdl1b.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 1b failed!")
 if not np.array_equal(
     np.round(np.array(mdl1b.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 1b failed!")
 
@@ -186,7 +186,7 @@ if not np.array_equal(np.array(mdl2b.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 2b failed!")
 if not np.array_equal(
     np.round(np.array(mdl2b.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 2b failed!")
 

--- a/Python/tests/test1_pip.py
+++ b/Python/tests/test1_pip.py
@@ -116,7 +116,7 @@ if not np.array_equal(np.array(mdl1a.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 1a failed!")
 if not np.array_equal(
     np.round(np.array(mdl1a.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 1a failed!")
 
@@ -134,7 +134,7 @@ if not np.array_equal(np.array(mdl2a.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 2a failed!")
 if not np.array_equal(
     np.round(np.array(mdl2a.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 2a failed!")
 
@@ -164,7 +164,7 @@ if not np.array_equal(np.array(mdl1b.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 1b failed!")
 if not np.array_equal(
     np.round(np.array(mdl1b.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 1b failed!")
 
@@ -182,7 +182,7 @@ if not np.array_equal(np.array(mdl2b.getPolicy()), np.array([1, 1, 0])):
     sys.exit("Model 2b failed!")
 if not np.array_equal(
     np.round(np.array(mdl2b.getValueVector()), 3),
-    np.round(np.array([354.2101307157537, 368.21018917357264, 457.21037278800077]), 3),
+    np.round(np.array([367.6724223596708, 381.67249768303293, 470.67273547568027]), 3),
 ):
     sys.exit("Model 2b failed!")
 


### PR DESCRIPTION
Fixes a real undefined-behavior bug (`norm` read before initialization in `ModifiedPolicyIteration`, found via Valgrind) and regenerates the average-reward test reference values it affected. Verified via a manual workflow_dispatch run across Linux, Windows, and macOS before merging. Bumps version to 0.10.1 (patch-bug fix only).